### PR TITLE
Fix dataset loading and README typos

### DIFF
--- a/Decision Tree Heart Diases.ipynb
+++ b/Decision Tree Heart Diases.ipynb
@@ -47,7 +47,7 @@
     {
       "cell_type": "code",
       "source": [
-        "df = pd.read_csv('processed.cleveland.data', header=None)\n",
+        "df = pd.read_csv('https://archive.ics.uci.edu/ml/machine-learning-databases/heart-disease/processed.cleveland.data', header=None)\n",
         "df.head()"
       ],
       "metadata": {

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-En este repositorio busco aplicar los conocmientos adquiridos de tecnicas de machine learning 
+En este repositorio busco aplicar los conocimientos adquiridos de técnicas de machine learning
 * Regresión Lineal
 * Regresión logistica
 * Clustering
 * Arboles de regresión
-* SMV 
+* SVM
 * K Means
 * Sistemas de recomendación
 * PCA  (Análisis de componentes principales)
@@ -15,5 +15,4 @@ En este repositorio busco aplicar los conocmientos adquiridos de tecnicas de mac
 * Keras regressor completo
 * Keras regressor Basico
 * Keras Clasification complete
-* 
   


### PR DESCRIPTION
## Summary
- fix typo in README
- load heart disease dataset from official UCI URL in Decision Tree notebook

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841a50a4410832d8df260b073660568